### PR TITLE
Parsed TPTP and TSTP comments

### DIFF
--- a/src/Athena/TSTP.hs
+++ b/src/Athena/TSTP.hs
@@ -1,8 +1,7 @@
 -- | Athena.TSTP module.
 -- Adapted from https://github.com/agomezl/tstp2agda.
 
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UnicodeSyntax       #-}
+{-# LANGUAGE UnicodeSyntax #-}
 
 
 module Athena.TSTP
@@ -16,8 +15,6 @@ import Athena.TSTP.Lexer  ( alexScanTokens )
 import Athena.TSTP.Parser ( parseTSTP )
 
 import Data.TSTP.F
-
-import Data.List          ( isPrefixOf )
 
 ------------------------------------------------------------------------------
 
@@ -47,10 +44,4 @@ parse ∷ String → [F]
 parse = parseTSTP . fmap snd . alexScanTokens
 
 parseFile ∷ FilePath → IO [F]
-parseFile path = do
-  contents ∷ String ← readFile path
-
-  let vlines ∷ String
-      vlines = unlines . filter (not . isPrefixOf "%") . lines $ contents
-
-  return $ parse vlines
+parseFile path = parse <$> readFile path

--- a/src/Athena/TSTP/Lexer.x
+++ b/src/Athena/TSTP/Lexer.x
@@ -51,6 +51,7 @@ $viewable_char      = [$printable_char\n]
 tokens :-
 
   $white+                                      ;
+  "%".*                                        ;  -- TPTP or TSTP comment line
   "("                                          { withPos $ const LP }
   "["                                          { withPos $ const Lbrack }
   "]"                                          { withPos $ const Rbrack }
@@ -59,7 +60,7 @@ tokens :-
   "!="|"="|"<=>"|"<="|"=>"|"<~>"|"&"|"|"
       |"~|"|"~&"|"!"|"?"|":"|"~"               { withPos $ Oper }
   "."                                          { withPos $ const Dot }
-  ("%"|"#")$printable_char*                    { withPos $ CommentToken } -- comment line
+  "#"$printable_char*                          { withPos $ CommentToken } -- comment line
   "/*" @not_star_slash "*"("*"*)"/"            { withPos $ CommentToken } -- comment block
   "SZS"$printable_char*                        ;
   @metis_sep                                   ;


### PR DESCRIPTION
I fixed the parsing of TPTP/TSTP comments.

For testing I ran

```
make problems
make reconstruct
make check
```

The last command generated many errors of the form

```
The name of the top level module does not match the file name. The
module impl-7 should be defined in one of the following files
```

Do I need to make something else?


